### PR TITLE
Initialize backend boilerplate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+DATABASE_URL="mongodb://localhost:27017/dcms"
+JWT_SECRET=your_jwt_secret
+REDIS_URL=redis://localhost:6379

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production || true
+COPY . .
+RUN npx prisma generate
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# dcms_portal_be
+# DCMS Portal Backend Boilerplate
+
+This project provides a production-ready boilerplate using **Node.js**, **Express**, **Prisma** with MongoDB, **BullMQ**, **Redis**, **JWT** authentication and **Swagger** documentation.
+
+## Features
+- Modular folder structure
+- Prisma MongoDB setup
+- Job queue using BullMQ
+- Centralized validation with Zod
+- Swagger documentation
+- Jest + Supertest test setup
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in values.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Generate Prisma client:
+   ```bash
+   npx prisma generate
+   ```
+4. Start development server:
+   ```bash
+   npm run dev
+   ```
+
+## Tests
+
+Run tests with:
+```bash
+npm test
+```
+
+## Docker
+
+Use `docker-compose` to run the API along with MongoDB and Redis.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  api:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=mongodb://mongo:27017/dcms
+      - REDIS_URL=redis://redis:6379
+      - JWT_SECRET=secret
+    depends_on:
+      - mongo
+      - redis
+  mongo:
+    image: mongo:5
+    ports:
+      - "27017:27017"
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+const app = require('./src/config/express');
+const { connect: connectDB } = require('./src/config/database');
+const { connectQueue } = require('./src/config/queue');
+
+const PORT = process.env.PORT || 3000;
+
+async function start() {
+  await connectDB();
+  await connectQueue();
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+start();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "dcms_portal_be",
+  "version": "1.0.0",
+  "description": "Backend boilerplate for DCMS Portal",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "dotenv": "^16.1.4",
+    "morgan": "^1.10.0",
+    "jsonwebtoken": "^9.0.0",
+    "bcryptjs": "^2.4.3",
+    "zod": "^3.22.2",
+    "prisma": "^5.2.0",
+    "@prisma/client": "^5.2.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.6.3",
+    "bullmq": "^4.7.1",
+    "ioredis": "^5.3.2",
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "nodemon": "^2.0.22"
+  }
+}

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,0 +1,15 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+async function connect() {
+  try {
+    await prisma.$connect();
+    console.log('Connected to MongoDB');
+  } catch (error) {
+    console.error('MongoDB connection error:', error);
+    process.exit(1);
+  }
+}
+
+module.exports = { prisma, connect };

--- a/src/config/express.js
+++ b/src/config/express.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const morgan = require('morgan');
+const cors = require('cors');
+const routes = require('../routes');
+const { errorHandler } = require('../middlewares/error');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpec = require('../docs/swagger');
+
+require('dotenv').config();
+
+const app = express();
+
+app.use(cors());
+app.use(morgan('dev'));
+app.use(express.json());
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use('/api', routes);
+
+app.use(errorHandler);
+
+module.exports = app;

--- a/src/config/queue.js
+++ b/src/config/queue.js
@@ -1,0 +1,17 @@
+const { Queue } = require('bullmq');
+const Redis = require('ioredis');
+
+const connection = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+
+const emailQueue = new Queue('email', { connection });
+
+async function connectQueue() {
+  try {
+    await connection.ping();
+    console.log('Connected to Redis');
+  } catch (error) {
+    console.error('Redis connection error:', error);
+  }
+}
+
+module.exports = { emailQueue, connectQueue };

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,0 +1,17 @@
+const { createUser, generateToken } = require('../services/authService');
+
+async function signup(req, res, next) {
+  try {
+    const user = await createUser(req.body);
+    const token = generateToken(user);
+    res.status(201).json({ token });
+  } catch (err) {
+    if (err.code === 'P2002') {
+      err.status = 400;
+      err.message = 'Email already exists';
+    }
+    next(err);
+  }
+}
+
+module.exports = { signup };

--- a/src/docs/api.yaml
+++ b/src/docs/api.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: DCMS Portal API
+  version: 1.0.0
+paths:
+  /api/auth/signup:
+    post:
+      summary: User signup
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - email
+                - password
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        '400':
+          description: Validation error

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -1,0 +1,8 @@
+const swaggerJSDoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {},
+  apis: ['./src/docs/api.yaml'],
+};
+
+module.exports = swaggerJSDoc(options);

--- a/src/jobs/emailReminder.js
+++ b/src/jobs/emailReminder.js
@@ -1,0 +1,9 @@
+const { Worker } = require('bullmq');
+const { emailQueue } = require('../config/queue');
+
+const worker = new Worker(emailQueue.name, async job => {
+  console.log('Processing job', job.id, job.data);
+  // TODO: send email
+});
+
+module.exports = worker;

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,0 +1,15 @@
+const jwt = require('jsonwebtoken');
+
+function authenticate(req, res, next) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+module.exports = { authenticate };

--- a/src/middlewares/error.js
+++ b/src/middlewares/error.js
@@ -1,0 +1,9 @@
+function errorHandler(err, req, res, next) {
+  console.error(err);
+  const status = err.status || 500;
+  res.status(status).json({
+    error: err.message || 'Internal Server Error',
+  });
+}
+
+module.exports = { errorHandler };

--- a/src/middlewares/validate.js
+++ b/src/middlewares/validate.js
@@ -1,0 +1,12 @@
+function validate(schema) {
+  return (req, res, next) => {
+    try {
+      req.body = schema.parse(req.body);
+      next();
+    } catch (err) {
+      return res.status(400).json({ error: err.errors });
+    }
+  };
+}
+
+module.exports = { validate };

--- a/src/models/schema.prisma
+++ b/src/models/schema.prisma
@@ -1,0 +1,16 @@
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id       String   @id @default(auto()) @map("_id") @db.ObjectId
+  name     String
+  email    String   @unique
+  password String
+  createdAt DateTime @default(now())
+}

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const { signup } = require('../controllers/authController');
+const { validate } = require('../middlewares/validate');
+const { signupSchema } = require('../validators/auth');
+
+router.post('/signup', validate(signupSchema), signup);
+
+module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,6 @@
+const router = require('express').Router();
+const authRoutes = require('./auth');
+
+router.use('/auth', authRoutes);
+
+module.exports = router;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,19 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { prisma } = require('../config/database');
+
+async function createUser(data) {
+  const hashed = await bcrypt.hash(data.password, 10);
+  const user = await prisma.user.create({
+    data: { name: data.name, email: data.email, password: hashed },
+  });
+  return user;
+}
+
+function generateToken(user) {
+  return jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET, {
+    expiresIn: '1h',
+  });
+}
+
+module.exports = { createUser, generateToken };

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,0 +1,7 @@
+const jwt = require('jsonwebtoken');
+
+function sign(payload) {
+  return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
+}
+
+module.exports = { sign };

--- a/src/validators/auth.js
+++ b/src/validators/auth.js
@@ -1,0 +1,9 @@
+const { z } = require('zod');
+
+const signupSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+module.exports = { signupSchema };

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,21 @@
+const request = require('supertest');
+const app = require('../src/config/express');
+const { prisma } = require('../src/config/database');
+
+describe('POST /api/auth/signup', () => {
+  beforeAll(async () => {
+    await prisma.user.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('should signup user and return token', async () => {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({ name: 'Test', email: 'test@example.com', password: 'secret123' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.token).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- implement Node/Express backend boilerplate
- add auth signup endpoint with Prisma, JWT, Zod
- set up Swagger docs, BullMQ, Redis, Mongo
- include Dockerfile and docker-compose
- provide Jest test for signup
- add environment template

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684689a2e700832d8b5e427527594740