### PR TITLE
Implement role-based auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "swagger-ui-express": "^4.6.3",
     "bullmq": "^4.7.1",
     "ioredis": "^5.3.2",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "cookie-parser": "^1.4.6"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/src/config/express.js
+++ b/src/config/express.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const morgan = require('morgan');
 const cors = require('cors');
+const cookieParser = require('cookie-parser');
 const routes = require('../routes');
 const { errorHandler } = require('../middlewares/error');
 const swaggerUi = require('swagger-ui-express');
@@ -13,6 +14,7 @@ const app = express();
 app.use(cors());
 app.use(morgan('dev'));
 app.use(express.json());
+app.use(cookieParser());
 
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use('/api', routes);

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,17 +1,83 @@
-const { createUser, generateToken } = require('../services/authService');
+const {
+  getUserByEmail,
+  validatePassword,
+  generateAccessToken,
+  createRefreshToken,
+  deleteRefreshToken,
+  rotateRefreshToken,
+  createUser,
+} = require('../services/authService');
+
+function getCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'strict',
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+  };
+}
 
 async function signup(req, res, next) {
   try {
     const user = await createUser(req.body);
-    const token = generateToken(user);
-    res.status(201).json({ token });
+    const accessToken = generateAccessToken(user);
+    const refreshToken = await createRefreshToken(user.id);
+    res.cookie('refreshToken', refreshToken.token, getCookieOptions());
+    res.status(201).json({ accessToken });
   } catch (err) {
     if (err.code === 'P2002') {
-      err.status = 400;
-      err.message = 'Email already exists';
+      return res.status(400).json({ error: 'Email already exists' });
     }
     next(err);
   }
 }
 
-module.exports = { signup };
+async function login(req, res, next) {
+  try {
+    const { email, password } = req.body;
+    const user = await getUserByEmail(email);
+    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+    const valid = await validatePassword(password, user.password);
+    if (!valid) return res.status(401).json({ error: 'Invalid credentials' });
+
+    const accessToken = generateAccessToken(user);
+    const refreshToken = await createRefreshToken(user.id);
+    res.cookie('refreshToken', refreshToken.token, getCookieOptions());
+    res.json({ accessToken });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function logout(req, res, next) {
+  try {
+    const token = req.cookies.refreshToken;
+    if (token) await deleteRefreshToken(token);
+    res.clearCookie('refreshToken');
+    res.json({ message: 'Logged out' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function refresh(req, res, next) {
+  try {
+    const token = req.cookies.refreshToken;
+    if (!token) return res.status(401).json({ error: 'Unauthorized' });
+    const data = await rotateRefreshToken(token);
+    if (!data) return res.status(401).json({ error: 'Unauthorized' });
+
+    const accessToken = generateAccessToken(data.user);
+    res.cookie('refreshToken', data.newToken.token, getCookieOptions());
+    res.json({ accessToken });
+  } catch (err) {
+    next(err);
+  }
+}
+
+function me(req, res) {
+  const { user } = req;
+  res.json({ id: user.userId, role: user.role });
+}
+
+module.exports = { signup, login, logout, refresh, me };

--- a/src/docs/api.yaml
+++ b/src/docs/api.yaml
@@ -25,15 +25,85 @@ paths:
                   type: string
                 password:
                   type: string
+                role:
+                  type: string
       responses:
         '201':
-          description: Created
+          description: Access token
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  token:
+                  accessToken:
                     type: string
-        '400':
-          description: Validation error
+  /api/auth/login:
+    post:
+      summary: User login
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Access token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+  /api/auth/logout:
+    post:
+      summary: Logout user
+      tags:
+        - Auth
+      responses:
+        '200':
+          description: Logged out
+  /api/auth/refresh:
+    post:
+      summary: Refresh token
+      tags:
+        - Auth
+      responses:
+        '200':
+          description: New access token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+  /api/auth/me:
+    get:
+      summary: Current user
+      tags:
+        - Auth
+      responses:
+        '200':
+          description: User info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  role:
+                    type: string
+

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,15 +1,20 @@
 const jwt = require('jsonwebtoken');
 
-function authenticate(req, res, next) {
-  const token = req.headers.authorization?.split(' ')[1];
-  if (!token) return res.status(401).json({ error: 'Unauthorized' });
-  try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = payload;
-    next();
-  } catch (err) {
-    return res.status(401).json({ error: 'Invalid token' });
-  }
+function authMiddleware(roles = []) {
+  return (req, res, next) => {
+    const token = req.headers.authorization?.split(' ')[1];
+    if (!token) return res.status(401).json({ error: 'Unauthorized' });
+    try {
+      const payload = jwt.verify(token, process.env.JWT_SECRET);
+      if (roles.length && !roles.includes(payload.role)) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      req.user = payload;
+      next();
+    } catch (err) {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+  };
 }
 
-module.exports = { authenticate };
+module.exports = { authMiddleware };

--- a/src/models/schema.prisma
+++ b/src/models/schema.prisma
@@ -12,5 +12,16 @@ model User {
   name     String
   email    String   @unique
   password String
+  role     String
+  createdAt DateTime @default(now())
+  refreshTokens RefreshToken[]
+}
+
+model RefreshToken {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  token     String   @unique
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String   @db.ObjectId
+  expiresAt DateTime
   createdAt DateTime @default(now())
 }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,8 +1,13 @@
 const router = require('express').Router();
-const { signup } = require('../controllers/authController');
+const { signup, login, logout, refresh, me } = require('../controllers/authController');
 const { validate } = require('../middlewares/validate');
-const { signupSchema } = require('../validators/auth');
+const { loginSchema, signupSchema } = require('../validators/auth');
+const { authMiddleware } = require('../middlewares/auth');
 
+router.post('/login', validate(loginSchema), login);
+router.post('/logout', logout);
+router.post('/refresh', refresh);
+router.get('/me', authMiddleware(), me);
 router.post('/signup', validate(signupSchema), signup);
 
 module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,8 @@
 const router = require('express').Router();
 const authRoutes = require('./auth');
+const protectedRoutes = require('./protected');
 
 router.use('/auth', authRoutes);
+router.use('/protected', protectedRoutes);
 
 module.exports = router;

--- a/src/routes/protected.js
+++ b/src/routes/protected.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const { authMiddleware } = require('../middlewares/auth');
+
+router.get('/admin', authMiddleware(['admin']), (req, res) => {
+  res.json({ message: 'admin access' });
+});
+
+module.exports = router;
+

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,19 +1,70 @@
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
 const { prisma } = require('../config/database');
 
 async function createUser(data) {
   const hashed = await bcrypt.hash(data.password, 10);
-  const user = await prisma.user.create({
-    data: { name: data.name, email: data.email, password: hashed },
-  });
-  return user;
-}
-
-function generateToken(user) {
-  return jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET, {
-    expiresIn: '1h',
+  return prisma.user.create({
+    data: {
+      name: data.name,
+      email: data.email,
+      password: hashed,
+      role: data.role || 'receptionist',
+    },
   });
 }
 
-module.exports = { createUser, generateToken };
+function generateAccessToken(user) {
+  return jwt.sign(
+    { userId: user.id, role: user.role },
+    process.env.JWT_SECRET,
+    { expiresIn: '15m' }
+  );
+}
+
+async function getUserByEmail(email) {
+  return prisma.user.findUnique({ where: { email } });
+}
+
+async function validatePassword(password, hash) {
+  return bcrypt.compare(password, hash);
+}
+
+async function createRefreshToken(userId) {
+  const token = crypto.randomBytes(40).toString('hex');
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const newToken = await prisma.refreshToken.create({
+    data: { token, userId, expiresAt },
+  });
+  return newToken;
+}
+
+async function deleteRefreshToken(token) {
+  await prisma.refreshToken.deleteMany({ where: { token } });
+}
+
+async function rotateRefreshToken(token) {
+  const stored = await prisma.refreshToken.findUnique({
+    where: { token },
+    include: { user: true },
+  });
+  if (!stored || stored.expiresAt < new Date()) {
+    if (stored) await prisma.refreshToken.delete({ where: { token } });
+    return null;
+  }
+  await prisma.refreshToken.delete({ where: { token } });
+  const newToken = await createRefreshToken(stored.userId);
+  return { user: stored.user, newToken };
+}
+
+module.exports = {
+  createUser,
+  generateAccessToken,
+  getUserByEmail,
+  validatePassword,
+  createRefreshToken,
+  deleteRefreshToken,
+  rotateRefreshToken,
+};
+

--- a/src/validators/auth.js
+++ b/src/validators/auth.js
@@ -1,9 +1,15 @@
 const { z } = require('zod');
 
-const signupSchema = z.object({
-  name: z.string().min(1),
+const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(6),
 });
 
-module.exports = { signupSchema };
+const signupSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+  role: z.enum(['admin', 'receptionist', 'dentist']).optional(),
+});
+
+module.exports = { loginSchema, signupSchema };

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,21 +1,78 @@
 const request = require('supertest');
+const bcrypt = require('bcryptjs');
 const app = require('../src/config/express');
 const { prisma } = require('../src/config/database');
 
-describe('POST /api/auth/signup', () => {
-  beforeAll(async () => {
-    await prisma.user.deleteMany();
-  });
+let accessToken;
+let refreshCookie;
 
-  afterAll(async () => {
-    await prisma.$disconnect();
+beforeAll(async () => {
+  await prisma.refreshToken.deleteMany();
+  await prisma.user.deleteMany();
+  const password = await bcrypt.hash('secret123', 10);
+  await prisma.user.create({
+    data: { name: 'Admin', email: 'admin@test.com', password, role: 'admin' },
   });
-
-  it('should signup user and return token', async () => {
-    const res = await request(app)
-      .post('/api/auth/signup')
-      .send({ name: 'Test', email: 'test@example.com', password: 'secret123' });
-    expect(res.statusCode).toBe(201);
-    expect(res.body.token).toBeDefined();
+  const password2 = await bcrypt.hash('pass1234', 10);
+  await prisma.user.create({
+    data: { name: 'Rec', email: 'rec@test.com', password: password2, role: 'receptionist' },
   });
 });
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('signup creates user and returns token', async () => {
+  const res = await request(app)
+    .post('/api/auth/signup')
+    .send({ name: 'Dent', email: 'dent@test.com', password: 'teeth123', role: 'dentist' });
+  expect(res.statusCode).toBe(201);
+  expect(res.body.accessToken).toBeDefined();
+});
+
+test('login returns tokens', async () => {
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ email: 'admin@test.com', password: 'secret123' });
+  expect(res.statusCode).toBe(200);
+  expect(res.body.accessToken).toBeDefined();
+  expect(res.headers['set-cookie']).toBeDefined();
+  refreshCookie = res.headers['set-cookie'][0];
+  accessToken = res.body.accessToken;
+});
+
+test('me returns user info', async () => {
+  const res = await request(app)
+    .get('/api/auth/me')
+    .set('Authorization', `Bearer ${accessToken}`);
+  expect(res.statusCode).toBe(200);
+  expect(res.body.role).toBe('admin');
+});
+
+test('refresh rotates token', async () => {
+  const res = await request(app)
+    .post('/api/auth/refresh')
+    .set('Cookie', refreshCookie);
+  expect(res.statusCode).toBe(200);
+  expect(res.body.accessToken).toBeDefined();
+});
+
+test('logout clears cookie', async () => {
+  const res = await request(app)
+    .post('/api/auth/logout')
+    .set('Cookie', refreshCookie);
+  expect(res.statusCode).toBe(200);
+});
+
+test('role based access forbidden', async () => {
+  const loginRes = await request(app)
+    .post('/api/auth/login')
+    .send({ email: 'rec@test.com', password: 'pass1234' });
+  const token = loginRes.body.accessToken;
+  const res = await request(app)
+    .get('/api/protected/admin')
+    .set('Authorization', `Bearer ${token}`);
+  expect(res.statusCode).toBe(403);
+});
+


### PR DESCRIPTION
## Summary
- replace old signup logic with robust authentication
- add JWT login/logout/refresh/me APIs with refresh token rotation
- protect routes with role-based middleware
- document auth APIs
- add protected example route and comprehensive tests
- include cookie-parser and update Prisma models for roles and refresh tokens
- add signup API to allow registration

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cookie-parser)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846981d0468832db212b0668f3d6cca