### PR TITLE
Implement patient CRUD endpoints

### DIFF
--- a/src/controllers/patientController.js
+++ b/src/controllers/patientController.js
@@ -1,0 +1,44 @@
+const {
+  createPatient,
+  updatePatient,
+  deletePatient,
+  findPatientById,
+} = require('../services/patientService');
+const { isValidObjectId } = require('../utils/objectId');
+
+async function create(req, res, next) {
+  try {
+    const patient = await createPatient(req.body);
+    res.status(201).json(patient);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function update(req, res, next) {
+  try {
+    const { id } = req.params;
+    if (!isValidObjectId(id)) return res.status(400).json({ error: 'Invalid id' });
+    const existing = await findPatientById(id);
+    if (!existing) return res.status(404).json({ error: 'Patient not found' });
+    const patient = await updatePatient(id, req.body);
+    res.json(patient);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function remove(req, res, next) {
+  try {
+    const { id } = req.params;
+    if (!isValidObjectId(id)) return res.status(400).json({ error: 'Invalid id' });
+    const existing = await findPatientById(id);
+    if (!existing) return res.status(404).json({ error: 'Patient not found' });
+    await deletePatient(id);
+    res.json({ message: 'Patient deleted' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { create, update, remove };

--- a/src/docs/api.yaml
+++ b/src/docs/api.yaml
@@ -107,3 +107,75 @@ paths:
                   role:
                     type: string
 
+  /api/patients:
+    post:
+      summary: Create patient
+      tags:
+        - Patients
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - firstName
+                - lastName
+                - phone
+                - gender
+                - dateOfBirth
+                - address
+                - medicalHistory
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                phone:
+                  type: string
+                gender:
+                  type: string
+                dateOfBirth:
+                  type: string
+                address:
+                  type: string
+                medicalHistory:
+                  type: string
+      responses:
+        '201':
+          description: Created patient
+  /api/patients/{id}:
+    put:
+      summary: Edit patient
+      tags:
+        - Patients
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Updated patient
+    delete:
+      summary: Delete patient
+      tags:
+        - Patients
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Patient deleted

--- a/src/models/schema.prisma
+++ b/src/models/schema.prisma
@@ -25,3 +25,16 @@ model RefreshToken {
   expiresAt DateTime
   createdAt DateTime @default(now())
 }
+
+model Patient {
+  id            String   @id @default(auto()) @map("_id") @db.ObjectId
+  firstName     String
+  lastName      String
+  email         String?
+  phone         String
+  gender        String
+  dateOfBirth   DateTime
+  address       String
+  medicalHistory String
+  createdAt     DateTime @default(now())
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,8 +1,10 @@
 const router = require('express').Router();
 const authRoutes = require('./auth');
 const protectedRoutes = require('./protected');
+const patientRoutes = require('./patientRoutes');
 
 router.use('/auth', authRoutes);
 router.use('/protected', protectedRoutes);
+router.use('/patients', patientRoutes);
 
 module.exports = router;

--- a/src/routes/patientRoutes.js
+++ b/src/routes/patientRoutes.js
@@ -1,0 +1,11 @@
+const router = require('express').Router();
+const { create, update, remove } = require('../controllers/patientController');
+const { validate } = require('../middlewares/validate');
+const { authMiddleware } = require('../middlewares/auth');
+const { createPatientSchema, updatePatientSchema } = require('../validators/patientValidator');
+
+router.post('/', authMiddleware(['admin', 'receptionist']), validate(createPatientSchema), create);
+router.put('/:id', authMiddleware(['admin', 'receptionist', 'dentist']), validate(updatePatientSchema), update);
+router.delete('/:id', authMiddleware(['admin']), remove);
+
+module.exports = router;

--- a/src/services/patientService.js
+++ b/src/services/patientService.js
@@ -1,0 +1,24 @@
+const { prisma } = require('../config/database');
+
+async function createPatient(data) {
+  return prisma.patient.create({ data });
+}
+
+async function updatePatient(id, data) {
+  return prisma.patient.update({ where: { id }, data });
+}
+
+async function deletePatient(id) {
+  return prisma.patient.delete({ where: { id } });
+}
+
+async function findPatientById(id) {
+  return prisma.patient.findUnique({ where: { id } });
+}
+
+module.exports = {
+  createPatient,
+  updatePatient,
+  deletePatient,
+  findPatientById,
+};

--- a/src/utils/objectId.js
+++ b/src/utils/objectId.js
@@ -1,0 +1,5 @@
+function isValidObjectId(id) {
+  return /^[a-fA-F0-9]{24}$/.test(id);
+}
+
+module.exports = { isValidObjectId };

--- a/src/validators/patientValidator.js
+++ b/src/validators/patientValidator.js
@@ -1,0 +1,19 @@
+const { z } = require('zod');
+
+const createPatientSchema = z.object({
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  email: z.string().email().optional(),
+  phone: z.string().min(1),
+  gender: z.string().min(1),
+  dateOfBirth: z.string().min(1),
+  address: z.string().min(1),
+  medicalHistory: z.string().min(1),
+});
+
+const updatePatientSchema = createPatientSchema.partial();
+
+module.exports = {
+  createPatientSchema,
+  updatePatientSchema,
+};

--- a/tests/patient.test.js
+++ b/tests/patient.test.js
@@ -1,0 +1,84 @@
+const request = require('supertest');
+const bcrypt = require('bcryptjs');
+const app = require('../src/config/express');
+const { prisma } = require('../src/config/database');
+
+let adminToken;
+let recToken;
+let dentToken;
+let patientId;
+
+beforeAll(async () => {
+  await prisma.refreshToken.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.patient.deleteMany();
+
+  const adminPass = await bcrypt.hash('admin123', 10);
+  await prisma.user.create({ data: { name: 'Admin', email: 'admin@test.com', password: adminPass, role: 'admin' } });
+  const recPass = await bcrypt.hash('rec1234', 10);
+  await prisma.user.create({ data: { name: 'Rec', email: 'rec@test.com', password: recPass, role: 'receptionist' } });
+  const dentPass = await bcrypt.hash('dent1234', 10);
+  await prisma.user.create({ data: { name: 'Dent', email: 'dent@test.com', password: dentPass, role: 'dentist' } });
+
+  adminToken = (await request(app).post('/api/auth/login').send({ email: 'admin@test.com', password: 'admin123' })).body.accessToken;
+  recToken = (await request(app).post('/api/auth/login').send({ email: 'rec@test.com', password: 'rec1234' })).body.accessToken;
+  dentToken = (await request(app).post('/api/auth/login').send({ email: 'dent@test.com', password: 'dent1234' })).body.accessToken;
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('create patient', async () => {
+  const res = await request(app)
+    .post('/api/patients')
+    .set('Authorization', `Bearer ${recToken}`)
+    .send({
+      firstName: 'John',
+      lastName: 'Doe',
+      phone: '123',
+      gender: 'male',
+      dateOfBirth: '1990-01-01',
+      address: 'Street 1',
+      medicalHistory: 'none',
+    });
+  expect(res.statusCode).toBe(201);
+  expect(res.body.firstName).toBe('John');
+  patientId = res.body.id;
+});
+
+test('edit patient', async () => {
+  const res = await request(app)
+    .put(`/api/patients/${patientId}`)
+    .set('Authorization', `Bearer ${dentToken}`)
+    .send({ address: 'Street 2' });
+  expect(res.statusCode).toBe(200);
+  expect(res.body.address).toBe('Street 2');
+});
+
+test('delete patient', async () => {
+  const res = await request(app)
+    .delete(`/api/patients/${patientId}`)
+    .set('Authorization', `Bearer ${adminToken}`);
+  expect(res.statusCode).toBe(200);
+});
+
+test('role based delete forbidden', async () => {
+  const resCreate = await request(app)
+    .post('/api/patients')
+    .set('Authorization', `Bearer ${recToken}`)
+    .send({
+      firstName: 'Jane',
+      lastName: 'Smith',
+      phone: '555',
+      gender: 'female',
+      dateOfBirth: '1985-01-01',
+      address: 'Street 3',
+      medicalHistory: 'none',
+    });
+  const id = resCreate.body.id;
+  const res = await request(app)
+    .delete(`/api/patients/${id}`)
+    .set('Authorization', `Bearer ${recToken}`);
+  expect(res.statusCode).toBe(403);
+});


### PR DESCRIPTION
## Summary
- add Prisma Patient model
- create patient services, controller and routes
- add validation and objectId utility
- document patient API in Swagger
- include integration tests for patient endpoints

## Testing
- `npm test` *(fails: PrismaClientInitializationError - Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6846b0b16d74832dafdc585d50a75c15