### PR TITLE
Add appointment scheduler module

### DIFF
--- a/src/controllers/appointmentController.js
+++ b/src/controllers/appointmentController.js
@@ -1,0 +1,108 @@
+const {
+  createAppointment,
+  updateAppointment,
+  cancelAppointment,
+  findAppointmentById,
+  listAppointments,
+  hasConflict,
+} = require('../services/appointmentService');
+const { emailQueue } = require('../config/queue');
+const { isValidObjectId } = require('../utils/objectId');
+
+async function book(req, res, next) {
+  try {
+    const { patientId, doctorId, startTime, endTime, notes } = req.body;
+    if (!isValidObjectId(patientId) || !isValidObjectId(doctorId)) {
+      return res.status(400).json({ error: 'Invalid id' });
+    }
+    if (new Date(startTime) >= new Date(endTime)) {
+      return res.status(400).json({ error: 'Invalid time range' });
+    }
+    const conflict = await hasConflict({ doctorId, patientId, startTime, endTime });
+    if (conflict) return res.status(400).json({ error: 'Time slot unavailable' });
+    const appointment = await createAppointment({ patientId, doctorId, startTime: new Date(startTime), endTime: new Date(endTime), notes });
+    if (emailQueue && emailQueue.add) {
+      await emailQueue.add('appointmentReminder', { appointmentId: appointment.id });
+    }
+    res.status(201).json(appointment);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function reschedule(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { startTime, endTime } = req.body;
+    if (!isValidObjectId(id)) return res.status(400).json({ error: 'Invalid id' });
+    const appointment = await findAppointmentById(id);
+    if (!appointment) return res.status(404).json({ error: 'Appointment not found' });
+    if (new Date(startTime) >= new Date(endTime)) {
+      return res.status(400).json({ error: 'Invalid time range' });
+    }
+    const conflict = await hasConflict({ doctorId: appointment.doctorId, patientId: appointment.patientId, startTime, endTime }, id);
+    if (conflict) return res.status(400).json({ error: 'Time slot unavailable' });
+    const updated = await updateAppointment(id, { startTime: new Date(startTime), endTime: new Date(endTime) });
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function cancel(req, res, next) {
+  try {
+    const { id } = req.params;
+    if (!isValidObjectId(id)) return res.status(400).json({ error: 'Invalid id' });
+    const appointment = await findAppointmentById(id);
+    if (!appointment) return res.status(404).json({ error: 'Appointment not found' });
+    if (req.user.role === 'patient' && req.user.userId !== appointment.patientId) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const updated = await cancelAppointment(id);
+    if (emailQueue && emailQueue.add) {
+      await emailQueue.add('appointmentCancelled', { appointmentId: updated.id });
+    }
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function list(req, res, next) {
+  try {
+    const { doctorId, patientId, startDate, endDate, status } = req.query;
+    const filter = {};
+    if (doctorId) filter.doctorId = doctorId;
+    if (patientId) filter.patientId = patientId;
+    if (status) filter.status = status;
+    if (startDate || endDate) {
+      filter.startTime = {};
+      if (startDate) filter.startTime.gte = new Date(startDate);
+      if (endDate) filter.startTime.lte = new Date(endDate);
+    }
+    const role = req.user.role;
+    if (role === 'dentist') filter.doctorId = req.user.userId;
+    if (role === 'patient') filter.patientId = req.user.userId;
+    const appointments = await listAppointments(filter);
+    res.json(appointments);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function getOne(req, res, next) {
+  try {
+    const { id } = req.params;
+    if (!isValidObjectId(id)) return res.status(400).json({ error: 'Invalid id' });
+    const appointment = await findAppointmentById(id);
+    if (!appointment) return res.status(404).json({ error: 'Appointment not found' });
+    const role = req.user.role;
+    if (role === 'dentist' && appointment.doctorId !== req.user.userId) return res.status(403).json({ error: 'Forbidden' });
+    if (role === 'patient' && appointment.patientId !== req.user.userId) return res.status(403).json({ error: 'Forbidden' });
+    res.json(appointment);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { book, reschedule, cancel, list, getOne };

--- a/src/models/schema.prisma
+++ b/src/models/schema.prisma
@@ -15,6 +15,7 @@ model User {
   role     String
   createdAt DateTime @default(now())
   refreshTokens RefreshToken[]
+  appointments Appointment[] @relation("DoctorAppointments")
 }
 
 model RefreshToken {
@@ -37,4 +38,25 @@ model Patient {
   address       String
   medicalHistory String
   createdAt     DateTime @default(now())
+  appointments  Appointment[]
+}
+
+model Appointment {
+  id           String   @id @default(auto()) @map("_id") @db.ObjectId
+  patientId    String   @db.ObjectId
+  doctorId     String   @db.ObjectId
+  startTime    DateTime
+  endTime      DateTime
+  status       String   @default("scheduled")
+  notes        String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  /// Relations
+  patient      Patient  @relation(fields: [patientId], references: [id])
+  doctor       User     @relation("DoctorAppointments", fields: [doctorId], references: [id])
+
+  /// Recurring appointment fields
+  repeatInterval String?
+  repeatCount    Int?
+  repeatUntil    DateTime?
 }

--- a/src/routes/appointmentRoutes.js
+++ b/src/routes/appointmentRoutes.js
@@ -1,0 +1,22 @@
+const router = require('express').Router();
+const { validate } = require('../middlewares/validate');
+const { authMiddleware } = require('../middlewares/auth');
+const {
+  book,
+  reschedule,
+  cancel,
+  list,
+  getOne,
+} = require('../controllers/appointmentController');
+const {
+  createAppointmentSchema,
+  rescheduleAppointmentSchema,
+} = require('../validators/appointmentValidator');
+
+router.post('/', authMiddleware(['admin', 'receptionist', 'patient']), validate(createAppointmentSchema), book);
+router.put('/:id', authMiddleware(['admin', 'receptionist']), validate(rescheduleAppointmentSchema), reschedule);
+router.delete('/:id', authMiddleware(['admin', 'receptionist', 'patient']), cancel);
+router.get('/', authMiddleware(['admin', 'receptionist', 'dentist', 'patient']), list);
+router.get('/:id', authMiddleware(['admin', 'receptionist', 'dentist', 'patient']), getOne);
+
+module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,9 +2,11 @@ const router = require('express').Router();
 const authRoutes = require('./auth');
 const protectedRoutes = require('./protected');
 const patientRoutes = require('./patientRoutes');
+const appointmentRoutes = require('./appointmentRoutes');
 
 router.use('/auth', authRoutes);
 router.use('/protected', protectedRoutes);
 router.use('/patients', patientRoutes);
+router.use('/appointments', appointmentRoutes);
 
 module.exports = router;

--- a/src/services/appointmentService.js
+++ b/src/services/appointmentService.js
@@ -1,0 +1,47 @@
+const { prisma } = require('../config/database');
+
+async function createAppointment(data) {
+  return prisma.appointment.create({ data });
+}
+
+async function updateAppointment(id, data) {
+  return prisma.appointment.update({ where: { id }, data });
+}
+
+async function cancelAppointment(id) {
+  return prisma.appointment.update({ where: { id }, data: { status: 'cancelled' } });
+}
+
+async function findAppointmentById(id) {
+  return prisma.appointment.findUnique({ where: { id } });
+}
+
+async function listAppointments(filter) {
+  return prisma.appointment.findMany({ where: filter, orderBy: { startTime: 'asc' } });
+}
+
+async function hasConflict({ doctorId, patientId, startTime, endTime }, excludeId) {
+  const overlapFilter = {
+    startTime: { lt: endTime },
+    endTime: { gt: startTime },
+  };
+  const where = {
+    status: { not: 'cancelled' },
+    id: excludeId ? { not: excludeId } : undefined,
+    OR: [
+      { doctorId, ...overlapFilter },
+      { patientId, ...overlapFilter },
+    ],
+  };
+  const conflict = await prisma.appointment.findFirst({ where });
+  return !!conflict;
+}
+
+module.exports = {
+  createAppointment,
+  updateAppointment,
+  cancelAppointment,
+  findAppointmentById,
+  listAppointments,
+  hasConflict,
+};

--- a/src/validators/appointmentValidator.js
+++ b/src/validators/appointmentValidator.js
@@ -1,0 +1,19 @@
+const { z } = require('zod');
+
+const createAppointmentSchema = z.object({
+  patientId: z.string().length(24),
+  doctorId: z.string().length(24),
+  startTime: z.string().datetime(),
+  endTime: z.string().datetime(),
+  notes: z.string().optional(),
+});
+
+const rescheduleAppointmentSchema = z.object({
+  startTime: z.string().datetime(),
+  endTime: z.string().datetime(),
+});
+
+module.exports = {
+  createAppointmentSchema,
+  rescheduleAppointmentSchema,
+};

--- a/tests/appointment.test.js
+++ b/tests/appointment.test.js
@@ -1,0 +1,106 @@
+const request = require('supertest');
+const bcrypt = require('bcryptjs');
+const app = require('../src/config/express');
+const { prisma } = require('../src/config/database');
+
+let recToken;
+let patientToken;
+let dentToken;
+let appointmentId;
+let patientId;
+let dentId;
+
+beforeAll(async () => {
+  await prisma.refreshToken.deleteMany();
+  await prisma.appointment.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.patient.deleteMany();
+
+  const recPass = await bcrypt.hash('rec1234', 10);
+  await prisma.user.create({ data: { name: 'Rec', email: 'rec@test.com', password: recPass, role: 'receptionist' } });
+  const dentPass = await bcrypt.hash('dent1234', 10);
+  const dentist = await prisma.user.create({ data: { name: 'Dent', email: 'dent@test.com', password: dentPass, role: 'dentist' } });
+  dentId = dentist.id;
+  const patPass = await bcrypt.hash('pat1234', 10);
+  const patientUser = await prisma.user.create({ data: { name: 'Pat', email: 'pat@test.com', password: patPass, role: 'patient' } });
+  patientId = patientUser.id;
+  await prisma.patient.create({
+    data: {
+      id: patientUser.id,
+      firstName: 'Pat',
+      lastName: 'Smith',
+      phone: '123',
+      gender: 'male',
+      dateOfBirth: new Date('1990-01-01'),
+      address: 'Street',
+      medicalHistory: 'none',
+    },
+  });
+
+  recToken = (await request(app).post('/api/auth/login').send({ email: 'rec@test.com', password: 'rec1234' })).body.accessToken;
+  dentToken = (await request(app).post('/api/auth/login').send({ email: 'dent@test.com', password: 'dent1234' })).body.accessToken;
+  patientToken = (await request(app).post('/api/auth/login').send({ email: 'pat@test.com', password: 'pat1234' })).body.accessToken;
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('book appointment', async () => {
+  const res = await request(app)
+    .post('/api/appointments')
+    .set('Authorization', `Bearer ${recToken}`)
+    .send({
+      patientId,
+      doctorId: dentId,
+      startTime: '2030-01-01T10:00:00.000Z',
+      endTime: '2030-01-01T11:00:00.000Z',
+    });
+  expect(res.statusCode).toBe(201);
+  appointmentId = res.body.id;
+});
+
+test('conflict detection', async () => {
+  const res = await request(app)
+    .post('/api/appointments')
+    .set('Authorization', `Bearer ${recToken}`)
+    .send({
+      patientId,
+      doctorId: dentId,
+      startTime: '2030-01-01T10:30:00.000Z',
+      endTime: '2030-01-01T11:30:00.000Z',
+    });
+  expect(res.statusCode).toBe(400);
+});
+
+test('reschedule appointment', async () => {
+  const res = await request(app)
+    .put(`/api/appointments/${appointmentId}`)
+    .set('Authorization', `Bearer ${recToken}`)
+    .send({ startTime: '2030-01-01T12:00:00.000Z', endTime: '2030-01-01T13:00:00.000Z' });
+  expect(res.statusCode).toBe(200);
+});
+
+test('patient cancel own appointment', async () => {
+  const res = await request(app)
+    .delete(`/api/appointments/${appointmentId}`)
+    .set('Authorization', `Bearer ${patientToken}`);
+  expect(res.statusCode).toBe(200);
+  expect(res.body.status).toBe('cancelled');
+});
+
+test('list own appointments', async () => {
+  const res = await request(app)
+    .get('/api/appointments')
+    .set('Authorization', `Bearer ${patientToken}`);
+  expect(res.statusCode).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  res.body.forEach(a => expect(a.patientId).toBe(patientId));
+});
+
+test('get appointment details', async () => {
+  const res = await request(app)
+    .get(`/api/appointments/${appointmentId}`)
+    .set('Authorization', `Bearer ${patientToken}`);
+  expect(res.statusCode).toBe(200);
+});


### PR DESCRIPTION
## Summary
- implement Appointment model in Prisma with recurrence fields
- add appointment service and controller
- create validators and routes
- wire appointments route into app
- include Jest tests for appointment endpoints

## Testing
- `npm install`
- `npx prisma generate --schema=src/models/schema.prisma`
- `npm test` *(fails: MongoDB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6846b630bfdc832da1fb2ba6b0fd8980