### PR TITLE
Add build script and update README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,33 @@ This project provides a production-ready boilerplate using **Node.js**, **Expres
    ```bash
    npm install
    ```
-3. Generate Prisma client:
+3. Build the project (generates the Prisma client):
    ```bash
-   npx prisma generate --schema=src/models/schema.prisma
+   npm run build
    ```
 4. Start development server:
    ```bash
    npm run dev
    ```
+
+## Build
+
+Generate the Prisma client:
+```bash
+npm run build
+```
+
+## Run
+
+Start the development server:
+```bash
+npm run dev
+```
+
+Start the production server:
+```bash
+npm start
+```
 
 ## Tests
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "commonjs",
   "scripts": {
     "start": "node index.js",
-    "dev": "npx prisma generate --schema=src/models/schema.prisma && nodemon index.js",
+    "dev": "npm run build && nodemon index.js",
+    "build": "npx prisma generate --schema=src/models/schema.prisma",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a `build` script to generate Prisma client
- run the build step before `dev`
- document build and run commands in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684febb81058832d9556f9ecf9108c74